### PR TITLE
fix: license image not loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,5 +147,5 @@ You can refer to the following articles on the basics of Git and Github and also
 ## License
 
 <a href="https://github.com/ArslanYM/StarterHive/blob/main/LICENSE ">
- <img src="https://github.com/Sohoxic/StarterHive/blob/readme-update/assets/images/MIT-licence.png" />
+ <img src="assets/images/MIT-licence.png" />
 </a>


### PR DESCRIPTION
fixed issue #17.

I changed the path to local path, instead of github generated url.


