### PR TITLE
Update GUIDELINES.md

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -6,7 +6,7 @@
 4. Participants/contributors can also **open their issues**, but it needs to be verified and labelled by the maintainer. We respect all your contributions, whether it is an Issue or a Pull Request.
 6. When you raise an issue, make sure you get it assigned to you before you start working on that project.
 7. Each participant/contributor will be **assigned 1 issue (max)** at a time to work.
-8. Participants are expected to follow **project guidelines** and [**coding style**](https://pep8.org/"). **Structured code** is one of our top priorities.
+8. Participants are expected to follow **project guidelines** and [**coding style**](https://pep8.org/). **Structured code** is one of our top priorities.
 9. Try to **explain your approach** to solve any issue in the comments. This will increase the chances of you being assigned.
 10. Don't create issues that are **already listed**.
 11. Please don't pick up an issue already assigned to someone else. Work on the issues after it gets **assigned to you**.


### PR DESCRIPTION
Fixes: [Issue#19](https://github.com/ArslanYM/StarterHive/issues/19)

Resolution: Removed trailing Quotation mark (") in the hyperlink URI for "coding style" @line-no:9

Description: 
There is an trailing Quotation mark (") or its equivalent (%22) in the URI.
Because of that, the Page gives 404 error.

In Chrome :
<img width="166" alt="Screenshot 2023-05-25 at 2 01 06 PM" src="https://github.com/ArslanYM/StarterHive/assets/96583080/85d6f0af-6936-4de7-966f-4c3230178571">
In Safari :
<img width="250" alt="Screenshot 2023-05-25 at 1 58 11 PM" src="https://github.com/ArslanYM/StarterHive/assets/96583080/ac2a161f-fcae-443c-955c-29c492a8a55e">
Network Error :
<img width="825" alt="Screenshot 2023-05-25 at 2 06 10 PM" src="https://github.com/ArslanYM/StarterHive/assets/96583080/327a1a21-9c97-4481-a8b8-afb5e63abfc2">



