### PR TITLE
Open repo page in new tab

### DIFF
--- a/web/src/layouts/Header.jsx
+++ b/web/src/layouts/Header.jsx
@@ -23,6 +23,8 @@ const Header = () => {
     <a
       href="https://github.com/ArslanYM/StarterHive"
       aria-label="github-link"
+      target="_blank"
+      rel="noreferrer"
       className="space-x-2 flex items-center"
     >
       <span>GitHub</span>


### PR DESCRIPTION
#86 
Fixing the GitHub button to open repo page in a new tab instead of just redirecting.