### PR TITLE
fix: vertical padding 0.50rem added to the button

### DIFF
--- a/web/src/layouts/Header.jsx
+++ b/web/src/layouts/Header.jsx
@@ -19,7 +19,7 @@ const Header = () => {
           </span>
         </a>
         <div className="lg:w-2/5 inline-flex lg:justify-end ml-5 lg:ml-0">
-  <button className="inline-flex bg-gray-800 py-1 px-3 focus:outline-none duration-300 hover:bg-gray-700 rounded text-base mt-4 md:mt-0">
+  <button className="inline-flex bg-gray-800 py-2 px-3 focus:outline-none duration-300 hover:bg-gray-700 rounded text-base mt-4 md:mt-0">
     <a
       href="https://github.com/ArslanYM/StarterHive"
       aria-label="github-link"


### PR DESCRIPTION
### What does this PR do?
Fixes https://github.com/ArslanYM/StarterHive/issues/101

Type of change
Bug fix
Adds tailwind class to the github button to give it some vertical space to breath
![Screenshot from 2023-05-27 16-27-16](https://github.com/ArslanYM/StarterHive/assets/12849916/8c1a2e50-08f6-4632-b00f-1b1ff45e2dae)
