### PR TITLE
fix: open source text scale up to 110% from 90%

### DIFF
--- a/web/src/layouts/Hero.jsx
+++ b/web/src/layouts/Hero.jsx
@@ -15,7 +15,7 @@ const Hero = ({ children }) => {
            <h1 className=" block title-font sm:text-5xl text-4xl mb-4 font-extrabold text-white">
                                 Contribute to the world of 
  
-                        <p className="sm:inline-block  sm:ml-4 md:ml-0 text-yellow-500 hover:scale-90 transition-transform">
+                        <p className="sm:inline-block  sm:ml-4 md:ml-0 text-yellow-500 hover:scale-110 transition-transform">
                               Open Source
                         </p>
                         </h1>


### PR DESCRIPTION
### What does this PR do?
Fixes https://github.com/ArslanYM/StarterHive/issues/105

Type of change
Bug fix
Adds tailwind class to scale up the Open Source text to 110% earlier it was 90%
[screen-capture (1).webm](https://github.com/ArslanYM/StarterHive/assets/12849916/df0338d7-e778-4bca-aa7e-aab89c5775fe)
