### PR TITLE
Clicking on more details should redirect to Github profile 

### DIFF
--- a/web/src/pages/Contributors/ContributorsList.jsx
+++ b/web/src/pages/Contributors/ContributorsList.jsx
@@ -29,7 +29,7 @@ const ContributorsList = () => {
     return (
         <div className="flex flex-wrap -m-2">
             {contributors.map((contributor, index) => {
-                return <ContributorItem image={contributor.avatar_url} name={contributor.login} position={contributor.html_url} key={index} />
+                return <ContributorItem image={contributor.avatar_url} name={contributor.login} url={contributor.html_url} key={index} />
             })
             }
         </div>


### PR DESCRIPTION
This PR Solves the Issue of the more details function not working. Now, when you clink on "more details" in the contributors list, it redirects you to the github profile of the contributor