### PR TITLE
Feat: Remove Btn from header Icon

### DIFF
--- a/web/src/Context/ThemeContext.jsx
+++ b/web/src/Context/ThemeContext.jsx
@@ -1,54 +1,59 @@
-import { useState, createContext } from "react"
+import { useState, createContext } from "react";
 
-const ThemeContext = createContext()
+const ThemeContext = createContext();
 
 const SCREEN_THEME = {
-	Light_Theme: {
-		bg_Selected: "bg-gradient-to-r from-white-700 via-gray-900 to-black",
-		text_Color: "text-gray-700",
-		navBar_LinkColor: "bg-yellow-400",
-		navBar_GitBtnColor: "bg-white-400",
-		navBar_GitBtnIconColor: "text-black",
-		checked: false
-	},
-	Dark_Theme: {
-		bg_Selected: "bg-gradient-to-r from-gray-700 via-gray-900 to-black",
-		text_Color: "text-white",
-		navBar_LinkColor: "bg-gray-800",
-		navBar_BtnColor: "bg-gray-800",
-		navBar_GitBtnIconColor: "text-white",
-		checked: true
-	}
-}
+  Light_Theme: {
+    bg_Selected: "bg-gradient-to-r from-white-700 via-gray-900 to-black",
+    text_Color: "text-gray-700",
+    navBar_LinkColor: "bg-yellow-400",
+    navBar_LinkColorHover: "hover:bg-yellow-400",
+    navBar_BtnColor: "bg-slate-100",
+    navBar_GitBtnColor: "bg-white-400",
+    navBar_GitBtnIconColor: "text-black",
+    navBar_GitBtnIconBorder: "border-yellow-400",
+    navBar_GitHover: "hover:ring-yellow-400 ",
+    checked: false,
+  },
+  Dark_Theme: {
+    bg_Selected: "bg-gradient-to-r from-gray-700 via-gray-900 to-black",
+    text_Color: "text-white",
+    navBar_LinkColor: "bg-gray-800",
+    navBar_LinkColorHover: "hover:bg-gray-800",
+    navBar_BtnColor: "bg-gray-800",
+    navBar_GitBtnIconColor: "text-white",
+    navBar_GitBtnIconBorder: "border-purple-600",
+    navBar_GitHover: "hover:ring-purple-600 ",
+    checked: true,
+  },
+};
 
 // eslint-disable-next-line react/prop-types
 const ThemeProvider = ({ children }) => {
-	const [theme, setTheme] = useState(() => {
-		if (localStorage.getItem("Theme")) {
-			const localStorageTheme = JSON.parse(localStorage.getItem("Theme"))
-			return JSON.stringify(localStorageTheme) === JSON.stringify(SCREEN_THEME.Light_Theme)
-				? SCREEN_THEME.Dark_Theme
-				: SCREEN_THEME.Light_Theme
-		}
-		return SCREEN_THEME.Light_Theme
-	})
+  const [theme, setTheme] = useState(() => {
+    if (localStorage.getItem("Theme")) {
+      const localStorageTheme = JSON.parse(localStorage.getItem("Theme"));
+      return JSON.stringify(localStorageTheme) ===
+        JSON.stringify(SCREEN_THEME.Light_Theme)
+        ? SCREEN_THEME.Dark_Theme
+        : SCREEN_THEME.Light_Theme;
+    }
+    return SCREEN_THEME.Light_Theme;
+  });
 
-	const handleTheme = () => {
-		const theme_Selected = JSON.stringify(theme)
-		theme_Selected === JSON.stringify(SCREEN_THEME.Light_Theme)
-			? setTheme(SCREEN_THEME.Dark_Theme)
-			: setTheme(SCREEN_THEME.Light_Theme)
-		localStorage.setItem("Theme", JSON.stringify(theme))
-	}
+  const handleTheme = () => {
+    const theme_Selected = JSON.stringify(theme);
+    theme_Selected === JSON.stringify(SCREEN_THEME.Light_Theme)
+      ? setTheme(SCREEN_THEME.Dark_Theme)
+      : setTheme(SCREEN_THEME.Light_Theme);
+    localStorage.setItem("Theme", JSON.stringify(theme));
+  };
 
-	return (
-		<ThemeContext.Provider value={{ handleTheme, theme }}>
-			{children}
-		</ThemeContext.Provider>
-	)
-}
+  return (
+    <ThemeContext.Provider value={{ handleTheme, theme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
 
-export {
-	ThemeProvider,
-	ThemeContext
-}
+export { ThemeProvider, ThemeContext };

--- a/web/src/layouts/Header.jsx
+++ b/web/src/layouts/Header.jsx
@@ -3,52 +3,86 @@ import React, { useContext } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { FaGithub } from "react-icons/fa";
 
-import logo from "../assets/hive.svg"
+import logo from "../assets/hive.svg";
 import Switch from "../components/Switch/Switch";
 import { ThemeContext } from "../Context/ThemeContext";
 
-
 const Header = () => {
-  const { handleTheme, theme } = useContext(ThemeContext)
+  const { handleTheme, theme } = useContext(ThemeContext);
   const location = useLocation();
   const path = location.pathname;
   //const active = true;
   return (
-    <header className={`text-gray-400 ${theme.bg_Selected}  body-font flex-nowrap`}>
-      <div className="container mx-auto flex flex-wrap p-5  flex-col w-full md:flex-row items-center justify-between">
-        <nav className="flex  flex-wrap items-center text-base w-full justify-between md:width-unset md:justify-normal  ">
-          <Link to="/" className={` px-1 py-1 md:px-3  rounded hover:${theme.text_Color} cursor-pointer md:font-bold ${path == "/" && `${theme.navBar_LinkColor}  `}`}>
+    <header
+      className={`text-gray-400 ${theme.bg_Selected}  body-font flex-nowrap`}
+    >
+      <div className="container flex flex-col flex-wrap items-center justify-between w-full p-5 mx-auto md:flex-row">
+        <nav className="flex flex-wrap items-center justify-between w-full text-base md:width-unset md:justify-normal ">
+          <Link
+            to="/"
+            className={` px-1 py-1 md:px-3  rounded hover:${
+              theme.text_Color
+            } cursor-pointer md:font-bold ${
+              path == "/" && `${theme.navBar_LinkColor}  `
+            }`}
+          >
             Home
           </Link>
-          <Link to="/contributors" className={` px-1 py-1 md:px-3  rounded hover:${theme.text_Color} md:font-bold cursor-pointer ${path == "/contributors" && `${theme.navBar_LinkColor}  `}`}>
+          <Link
+            to="/contributors"
+            className={` px-1 py-1 md:px-3  rounded hover:${
+              theme.text_Color
+            } md:font-bold cursor-pointer ${
+              path == "/contributors" && `${theme.navBar_LinkColor}  `
+            }`}
+          >
             Contributors
           </Link>
-          <Link to="/docs" className={` px-1 py-1 md:px-3  rounded hover:${theme.text_Color} md:font-bold cursor-pointer ${path == "/docs" && `${theme.navBar_LinkColor}  `}`}>
+          <Link
+            to="/docs"
+            className={` px-1 py-1 md:px-3  rounded hover:${
+              theme.text_Color
+            } md:font-bold cursor-pointer ${
+              path == "/docs" && `${theme.navBar_LinkColor}  `
+            }`}
+          >
             Docs
           </Link>
-          <Link to="/issues" className={`hover:${theme.text_Color} cursor-pointer md:font-bold px-1 py-1 md:px-3 rounded ${path == "/issues" && `${theme.navBar_LinkColor}  `}`}>
+          <Link
+            to="/issues"
+            className={`hover:${
+              theme.text_Color
+            } cursor-pointer md:font-bold px-1 py-1 md:px-3 rounded ${
+              path == "/issues" && `${theme.navBar_LinkColor}  `
+            }`}
+          >
             Find Issues
           </Link>
         </nav>
-        <Link to="/" className="flex order-first  title-font font-medium items-center text-white  mb-4 md:mb-0">
-
-          <span className={`${theme.text_Color} ml-3 text-xl  font-bold cursor-pointer`}>Starter Hive </span>
-          <img src={logo} alt="Logo" className="ml-3 w-6" />
-
+        <Link
+          to="/"
+          className="flex items-center order-first mb-4 font-medium text-white title-font md:mb-0"
+        >
+          <span
+            className={`${theme.text_Color} ml-3 text-xl  font-bold cursor-pointer`}
+          >
+            Starter Hive{" "}
+          </span>
+          <img src={logo} alt="Logo" className="w-6 ml-3" />
         </Link>
-        <div className=" inline-flex ">
+        <div className="inline-flex ">
           <Switch handleTheme={handleTheme} checked={theme.checked} />
-          <button className={` inline-flex ${theme.navBar_BtnColor} py-2 px-3 border border-purple-600 rounded-full focus:outline-none duration-300 
-            hover:ring-2 hover:ring-purple-500 hover:ring-purple-500 transition-all ease-out duration-300 `}>
-            <a href="https://github.com/ArslanYM/StarterHive" aria-label="github-link" target="_blank" rel="noreferrer" className="space-x-2 flex items-center">
-              <span className="text-purple-600">GitHub</span>
-              <FaGithub className={` text-2xl  ${theme.navBar_GitBtnIconColor}`} />
-              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 ml-1 text-purple-600" 
-                fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 5l7 7m0 0l-7 7m7-7H3" />
-              </svg>
-            </a>
-          </button>
+          <a
+            href="https://github.com/ArslanYM/StarterHive"
+            aria-label="github-link"
+            target="_blank"
+            rel="noreferrer"
+            className={`p-2 hover:ring-2 rounded-full duration-300 ${theme.navBar_GitBtnIconBorder} ${theme.navBar_GitHover}  ${theme.navBar_BtnColor} flex items-center space-x-2`}
+          >
+            <FaGithub
+              className={` text-2xl  ${theme.navBar_GitBtnIconColor}`}
+            />
+          </a>
         </div>
       </div>
     </header>


### PR DESCRIPTION
This PR fixed #214 

- border and background of the Github header icon are dynamic now in light/dark mode.