### PR TITLE
Fix home page text appearance

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -16,3 +16,13 @@ body {
 .bg_Dark_Theme {
   background: #000000;
 }
+
+/* Fix the Home text appearance */
+.home-page-text {
+  margin: auto
+}
+
+/* add some gap betwen the text and the image on the home page */
+.home-page-container {
+  gap: 64px
+}

--- a/web/src/pages/Home/Home.jsx
+++ b/web/src/pages/Home/Home.jsx
@@ -10,8 +10,8 @@ const Home = () => {
   return (
     <>
       <section className="text-gray-400  body-font">
-        <div className="container flex flex-col items-center min-h-screen px-5 py-6 md:py-10 mx-auto md:flex-row">
-          <div className="flex flex-col items-center md:self-start md:pt-40 mb-16 text-center lg:flex-grow md:w-1/2 lg:pr-20 md:pr-16 md:items-start md:text-left md:mb-0">
+        <div className="container flex flex-col items-center min-h-screen px-5 py-6 md:py-10 mx-auto md:flex-row home-page-container">
+          <div className="flex flex-col items-center md:self-start md:pt-40 mb-16 text-center lg:flex-grow md:w-1/2 lg:pr-20 md:pr-16 md:items-start md:text-left md:mb-0 home-page-text">
             <h1
               className={`block mb-4 text-4xl font-extrabold ${theme.text_Color} title-font sm:text-5xl`}
             >


### PR DESCRIPTION
#Fix Home page text appearance
- the issue number:  #189
- [the issue link](https://github.com/ArslanYM/StarterHive/issues/189)
- I fixed the appearance of the home page text by adjusting the margins. I added a class to the div that contains the text and selected it in the CSS file, setting the margin to 'auto.' This adjustment resolved the issue the text appearance. However, it also removed the gap between the image and the text. To address this, I added the 'gap' property to the container and made further adjustments, ensuring everything looks as intended.