### PR TITLE
Fix search bar size

### DIFF
--- a/web/src/pages/Contributors/search/Search.jsx
+++ b/web/src/pages/Contributors/search/Search.jsx
@@ -1,7 +1,13 @@
 export default function SearchTerm({setTerm}){
     return (
         <div style={{width: "100%"}} >
-            <input type="text" onChange={(e)=>setTerm(e.target.value)} className="block w-1/3 mx-auto rounded-xl border-0 py-1.5 pl-7 pr-20 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" placeholder="Search"/>
+            <input
+                type="text"
+                    onChange={(e)=>setTerm(e.target.value)}
+                    className="block w-1/3 mx-auto rounded-xl border-0 py-1.5 pl-7 pr-20 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+                    placeholder="Search"
+                    style={{width: "380px", maxWidth: "100%"}}
+                />
             <br/>
         </div>
     )


### PR DESCRIPTION
Issue number: #270

#Fix search bar size

##The problem 🐞: 
This issue was solved by another contributor. However, after they resolved the problem for larger screens by dividing the size of the screen into 3 and applying it to the search bar, it looked good on large screens. Unfortunately, on smaller screens like phones, the appearance was very bad because the search bar became very small

##How I solved:
To address this, I adjusted the width of the search bar to 380px and set the max-width to 100% using the styling attribute. This modification made the search bar look nice on every screen size.

