### PR TITLE
Fix:#342 card overlapping and overflow cards in ultra small screen

### DIFF
--- a/web/src/pages/Issues/ListOfOrgs/ProjectCard.jsx
+++ b/web/src/pages/Issues/ListOfOrgs/ProjectCard.jsx
@@ -39,7 +39,7 @@ const ProjectCard = ({
   ));
 
   return (
-    <div className="flex self-auto flex-col h-full w-96 border rounded-lg shadow bg-gray-800 border-gray-700">
+    <div className="flex self-auto flex-col h-full w-96 max-w-full border rounded-lg shadow bg-gray-800 border-gray-700">
       <a href={projectLink}>
         <img
           rel="preload"


### PR DESCRIPTION
# Fix issues - #342 

## Fix 1. Overlapping cards, at width 794px
#### Before:

<img src="https://github.com/ArslanYM/StarterHive/assets/75106349/9bd4025f-bcec-4fcb-a045-939794b654a8" height="300" alt="overlapping screenshot">

#### After: 
<img src="https://github.com/ArslanYM/StarterHive/assets/75106349/c23cb34b-c07c-407a-898c-9715df40faec" height="300" alt="overlapping fix screenshot">

## Fix 2. Overflow card at a width less than 390px (device: Samsung fold)
#### Before:
<img src="https://github.com/ArslanYM/StarterHive/assets/75106349/25638ae1-b161-422f-b707-9db4184bfd43" height="400" alt="overflow screenshot">

#### After:
<img src="https://github.com/ArslanYM/StarterHive/assets/75106349/c9535c1d-4ef7-4b24-8838-6cc112c2b7e1" height="400" alt="overflow fix screenshot">



