### PR TITLE
Fix: Search box overflow in mobile screen

### DIFF
--- a/web/src/pages/Contributors/ContributorItem.jsx
+++ b/web/src/pages/Contributors/ContributorItem.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 const ContributorItem = ({ image, name, url }) => {
   return (
     <div className="p-2 lg:w-1/3 md:w-1/2 w-full">
-      <div className="h-full flex items-center border-gray-800 border p-4 rounded-lg hover:shadow-sm hover:shadow-purple-900 hover:border-gray-700 transition-all transform hover:scale-105">
+      <div className="h-full flex items-center border-gray-800 border p-4 rounded-lg hover:shadow-sm hover:shadow-purple-900 hover:border-gray-700 transition-all transform hover:scale-105 overflow-hidden">
         <img
           alt="team"
           className="w-16 h-16 bg-gray-100 object-cover object-center flex-shrink-0 rounded-full mr-4 transition duration-300 transform hover:scale-125"

--- a/web/src/pages/Contributors/search/Search.jsx
+++ b/web/src/pages/Contributors/search/Search.jsx
@@ -1,18 +1,21 @@
+import PropTypes from "prop-types";
 import search from "../../../assets/search.png";
 export default function SearchTerm({ setTerm }) {
   return (
-    <div className="w-[100%] flex justify-center mb-[12%] lg:mb-[5%]">
-      <div className="border-yellow-400 border-2 w-fit h-10 rounded-3xl flex">
-        <img src={search} alt="search" className="w-12 h-10 p-2 pl-4" />
+    <div className="w-full px-2 mb-14">
+      <div className="border-yellow-400 border-2 rounded-3xl flex mx-auto w-96 max-w-full">
+        <img src={search} alt="search" width={45} height={45} className="py-2 px-3"/>
         <input
           type="text"
           onChange={(e) => setTerm(e.target.value)}
-          className="search block w-1/3 rounded-3xl outline-none bg-transparent border-none py-1.5 pl-1 pr-20 text-yellow-500 font-medium  placeholder:text-yellow-500 sm:text-sm sm:leading-6"
+          className="flex-1 pr-4 w-fit outline-none bg-transparent text-yellow-500 font-medium placeholder:text-yellow-500"
           placeholder="Search"
-          style={{ width: "380px", maxWidth: "100%" }}
         />
       </div>
-      <br />
     </div>
   );
 }
+
+SearchTerm.propTypes = {
+  setTerm: PropTypes.func.isRequired,
+};


### PR DESCRIPTION
Fix issue #361

### Pull Request Overview:

This pull request fixes the "Search box overflow in mobile screen" to the contributor page, addressing the issue outlined in #361.

#### Screenshot
- At iPhone 12 Pro resolution (width `@390px`)
<img src="https://github.com/ArslanYM/StarterHive/assets/75106349/4975b907-794e-46ea-b2cf-f0b3cf66b27f" width="390" alt="screenshot">

- At Galaxy Fold resolution (width `@280px`)
<img src ="https://github.com/ArslanYM/StarterHive/assets/75106349/655a46b0-71fe-47a8-b5f3-ea377025aa34" width="280" alt="screenshot2">

> Please review this pull request, and your feedback is much appreciated.
