### PR TITLE
Add multiple selection for languages and topics

### DIFF
--- a/web/src/pages/Issues/LanguageDropDown.jsx
+++ b/web/src/pages/Issues/LanguageDropDown.jsx
@@ -5,8 +5,8 @@ import { MdArrowDropDown } from 'react-icons/md';
 
 const LanguageDropDown = ({
   languages,
-  selectedLanguage,
-  setSelectedLanguage,
+  selectedLanguages,
+  setSelectedLanguages,
 }) => {
   const [isDropDownVisible, setIsDropDownVisible] = useState(false); // To toggle dropdown
 
@@ -23,18 +23,21 @@ const LanguageDropDown = ({
   }, [languages]);
 
   // When a language is clicked
-  const onLanguageClick = (language) => {
-    setIsDropDownVisible(false);
-
+  const onLanguageClick = (e, language) => {
+    e.stopPropagation();
     // If the same language is clicked again, set selected language to 'All'
-    if (selectedLanguage === language) {
-      setSelectedLanguage('All');
+    if (selectedLanguages.includes(language)) {
+      setSelectedLanguages(selectedLanguages.filter(selected => selected !== language));
       return;
     }
 
     // Else set the selected language to the clicked language
-    setSelectedLanguage(language);
+    setSelectedLanguages([...selectedLanguages, language]);
   };
+
+  const handleClearAllSelected = () => {
+    setSelectedLanguages([]);
+  }
 
   return (
     <div className="max-w-full w-max border-2 border-yellow-400 relative text-white py-1 px-2 rounded-lg">
@@ -46,31 +49,47 @@ const LanguageDropDown = ({
           Language/Topic:{' '}
         </span>
         <span className="dropdown-container flex">
-          {selectedLanguage}
+          <span className="max-w-xs truncate dropdown-container" title={selectedLanguages.length > 0 ? (
+              selectedLanguages.join(', ')
+            ) : 'All'}>
+            {selectedLanguages.length === 0 && 'All'}
+            {selectedLanguages.length > 0 && (
+              selectedLanguages.join(', ')
+            )}
+          </span>
           <MdArrowDropDown className="dropdown-container text-2xl" />
         </span>
       </div>
       {isDropDownVisible && (
         <div
-          className={`max-h-96 overflow-x-auto absolute top-10 flex w-64 flex-col ju bg-gray-800 border border-gray-700 shadow-xl rounded-md z-10`}
+          className={` absolute top-10 flex w-64 flex-col ju bg-gray-800 border border-gray-700 shadow-xl rounded-md z-10`}
         >
-          <div className="px-4 py-2 border-b border-gray-700 opacity-60 text-sm">
-            Filter By Language / Topic
+          <div className='max-h-96 overflow-x-auto'>
+            <div className="px-4 py-2 border-b border-gray-700 opacity-60 text-sm">
+              Filter By Language / Topic
+            </div>
+            {languages.map((language, key) => {
+              return (
+                <div
+                  key={key}
+                  className="flex justify-between items-center border-b border-gray-700 px-4 py-2 cursor-pointer hover:bg-gray-600 duration-500 gap-x-1"
+                  onClick={(e) => onLanguageClick(e, language)}
+                >
+                  <span className="w-4 mt-1">
+                    {selectedLanguages.includes(language) && <BsCheck2 />}
+                  </span>
+                  <span className="flex-1">{language}</span>
+                </div>
+              );
+            })}
           </div>
-          {languages.map((language, key) => {
-            return (
-              <div
-                key={key}
-                className="flex justify-between items-center border-b border-gray-700 px-4 py-2 cursor-pointer hover:bg-gray-600 duration-500 gap-x-1"
-                onClick={() => onLanguageClick(language)}
-              >
-                <span className="w-4 mt-1">
-                  {selectedLanguage === language && <BsCheck2 />}
-                </span>
-                <span className="flex-1">{language}</span>
-              </div>
-            );
-          })}
+          {selectedLanguages.length > 0 && (
+            <div className='flex justify-center'>
+              <button onClick={handleClearAllSelected} className='dropdown-container text-xs p-2 hover:cursor-pointer text-yellow-600 underline'>
+                Clear all filters
+              </button>
+            </div>
+          )}
         </div>
       )}
     </div>
@@ -81,6 +100,6 @@ export default LanguageDropDown;
 
 LanguageDropDown.propTypes = {
   languages: PropTypes.array.isRequired,
-  selectedLanguage: PropTypes.string.isRequired,
-  setSelectedLanguage: PropTypes.func.isRequired,
+  selectedLanguages: PropTypes.array.isRequired,
+  setSelectedLanguages: PropTypes.func.isRequired,
 };

--- a/web/src/pages/Issues/ProjectList.jsx
+++ b/web/src/pages/Issues/ProjectList.jsx
@@ -1,13 +1,13 @@
 // eslint-disable-next-line no-unused-vars
 import React, { useEffect, useState } from 'react';
-import projectList from "./ListOfOrgs/listOfOrgs";
-import ProjectCard from "./ListOfOrgs/ProjectCard";
-import { ScaleLoader } from 'react-spinners';
 import { BsBookmark, BsFillBookmarkCheckFill } from 'react-icons/bs';
+import { ScaleLoader } from 'react-spinners';
 import LanguageDropDown from './LanguageDropDown';
+import ProjectCard from "./ListOfOrgs/ProjectCard";
+import projectList from "./ListOfOrgs/listOfOrgs";
 
 const ProjectList = () => {
-  const [selectedLanguage, setSelectedLanguage] = useState('All');
+  const [selectedLanguages, setSelectedLanguages] = useState([]);
   const [languages, setLanguages] = useState([]);
   const [bookMarkProjects, setBookMarkProjects] = useState();
   const [showBookMark, setShowBookMark] = useState(false);
@@ -15,25 +15,27 @@ const ProjectList = () => {
   // Filter projects by language or bookmark
   function filterProject(project) {
     // If the user wants to see all projects
-    if (selectedLanguage === 'All' && !showBookMark) {
+    if (selectedLanguages.length === 0 && !showBookMark) {
       return true;
     }
 
     // If the user wants to see only bookmarked projects
-    if (selectedLanguage === 'All' && showBookMark) {
+    if (selectedLanguages.length === 0 && showBookMark) {
       return bookMarkProjects.includes(project.projectLink);
     }
+
+    const isTagsMatch = selectedLanguages.every(language => project.tags.includes(language));
 
     // If the user wants to see only bookmark projects of a specific language
     if (showBookMark) {
       return (
-        project.tags.includes(selectedLanguage) &&
+        isTagsMatch &&
         bookMarkProjects.includes(project.projectLink)
       );
     }
 
     // If the user wants to see only projects of a specific language
-    return project.tags.includes(selectedLanguage);
+    return isTagsMatch;
   }
 
   // Get all the languages/tags from the project list
@@ -68,8 +70,8 @@ const ProjectList = () => {
       <div className="w-full my-4 p-4 flex items-center flex-wrap gap-4">
         <LanguageDropDown
           languages={languages}
-          selectedLanguage={selectedLanguage}
-          setSelectedLanguage={setSelectedLanguage}
+          selectedLanguages={selectedLanguages}
+          setSelectedLanguages={setSelectedLanguages}
         />
         <div
           onClick={() => setShowBookMark(!showBookMark)}


### PR DESCRIPTION
This pull request add the feature to select multiple languages and topics in the dropdown. Only projects that match with all options selected will appear.

When the user select any option, a button containing the text "Clear all filters" is displayed. After to clear all filters, all projects appear again.

![Captura de Tela 2023-10-06 às 18 40 00](https://github.com/ArslanYM/StarterHive/assets/12664500/88a80045-bd1e-42ec-9a4f-ecd26c63b806)

![Captura de Tela 2023-10-06 às 18 40 31](https://github.com/ArslanYM/StarterHive/assets/12664500/04fd70ef-b724-48cf-aefa-c20c0edf6d2c)

Resolve #373 